### PR TITLE
outdated comment

### DIFF
--- a/Network/Network/SimpleNetwork.swift
+++ b/Network/Network/SimpleNetwork.swift
@@ -24,7 +24,7 @@ class SimpleNetwork {
     }
 
     /**
-     The session that the app uses. Since it uses delegate: self, it must be declared lazy. You should never change this.
+     The session that the app uses.
      */
     let session: URLSession = URLSession()
 


### PR DESCRIPTION
session is not declared lazy and not using delegate self.

Kind of funny since it specifically says "You should never change this."